### PR TITLE
issue#10: Fixed a startup error caused by missing downloads folder.

### DIFF
--- a/src/MMT.Core/ProfileManager.cs
+++ b/src/MMT.Core/ProfileManager.cs
@@ -47,6 +47,7 @@ namespace MMT.Core
 
             Directory.CreateDirectory(Path.Combine(_customProfilesPath, profileName));
             Directory.CreateDirectory(Path.Combine(_customProfilesPath, profileName, "Desktop"));
+            Directory.CreateDirectory(Path.Combine(_customProfilesPath, profileName, "Downloads"));
         }
 
         public void Delete(string profileName)

--- a/src/MMT.Core/TeamsLauncher.cs
+++ b/src/MMT.Core/TeamsLauncher.cs
@@ -13,6 +13,9 @@ namespace MMT.Core
 
             string oldUserProfile = StaticResources.UserProfile;
             string userProfile = Path.Combine(StaticResources.LocalAppData, StaticResources.CustomProfiles, profileName);
+            Directory.CreateDirectory(userProfile);
+            Directory.CreateDirectory(Path.Combine(userProfile, "Desktop"));
+            Directory.CreateDirectory(Path.Combine(userProfile, "Downloads"));
             Environment.SetEnvironmentVariable("USERPROFILE", userProfile);
             string updateExePath = Path.Combine(oldUserProfile, StaticResources.UpdateExe);
             


### PR DESCRIPTION
Now always recreates needed folders before launching teams.
[original issue](https://github.com/TonCunha/multi-microsoft-teams/issues/10)