### PR TITLE
MultiSelect, Default-Profile, Context Menu and more XAML

### DIFF
--- a/src/MMT.Core/MMT.Core.csproj
+++ b/src/MMT.Core/MMT.Core.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MMT.Core/Profile.cs
+++ b/src/MMT.Core/Profile.cs
@@ -6,8 +6,6 @@
 
         public bool IsDefault { get; set; }
 
-        public bool IsEnabled => !IsDisabled;
-
         public string Name { get; set; }
 
         public string Path { get; set; }

--- a/src/MMT.Core/Profile.cs
+++ b/src/MMT.Core/Profile.cs
@@ -1,0 +1,21 @@
+﻿namespace MMT.Core
+{
+    public class Profile
+    {
+        public bool IsDisabled => ProfileManager.IsDisabled(this);
+
+        public bool IsDefault { get; set; }
+
+        public bool IsEnabled => !IsDisabled;
+
+        public string Name { get; set; }
+
+        public string Path { get; set; }
+
+        public Profile(string name, string path)
+        {
+            Name = name;
+            Path = path;
+        }
+    }
+}

--- a/src/MMT.Core/ProfileManager.cs
+++ b/src/MMT.Core/ProfileManager.cs
@@ -9,81 +9,76 @@ namespace MMT.Core
 {
     public class ProfileManager : INotifyPropertyChanged
     {
-        private IList<string> _profiles;
+        private IList<string> _profiles = new List<string>();
         public IList<string> Profiles => _profiles;
 
-        private readonly string _customProfilesPath;
+        private static readonly string _customProfilesPath = Path.Combine(StaticResources.LocalAppData, StaticResources.CustomProfiles);
 
-        public event PropertyChangedEventHandler PropertyChanged;
-        private void OnPropertyRaised(string propertyname)
-        {
-            if (propertyname == nameof(Profiles))
-            {
-                _profiles = GetProfiles();
-            }
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyname));
-            }
-        }
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyRaised(string propertyname) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyname));
 
         public ProfileManager()
         {
-            string localAppData = StaticResources.LocalAppData;
-            _customProfilesPath = Path.Combine(localAppData, StaticResources.CustomProfiles);
-            _profiles = GetProfiles();
+            UpdateProfiles();
         }
 
-        public List<string> GetProfiles()
+        private void UpdateProfiles()
         {
             if (!Directory.Exists(_customProfilesPath))
                 Directory.CreateDirectory(_customProfilesPath);
 
-            return Directory.GetDirectories(_customProfilesPath)
+            _profiles = Directory.GetDirectories(_customProfilesPath)
                 .Select(path => new DirectoryInfo(path).Name)
                 .Where(name => !String.IsNullOrWhiteSpace(name))
                 .Select(profile => IsDisabled(profile) ? $"[Disabled] {profile}" : profile)
                 .ToList();
+            _profiles.Insert(0, "[Default]");
+
+            OnPropertyRaised(nameof(Profiles));
         }
 
-        private string GetProfilePath (string profileName) => Path.Combine(_customProfilesPath, profileName);
+        private static string GetProfilePath (string profileName) => Path.Combine(_customProfilesPath, profileName);
 
         public void Save(string profileName)
         {
             if (string.IsNullOrWhiteSpace(profileName))
                 throw new ArgumentException("Profile name is required.");
 
-            if (GetProfiles().Any(p => p.ToUpper().Equals(profileName.ToUpper())))
+            if (Profiles.Any(p => String.Equals(p, profileName, StringComparison.OrdinalIgnoreCase)))
                 throw new ArgumentException("This profile already exists.");
 
+            // Create UserProfile-Folder-Structure
             var path = GetProfilePath(profileName);
             Directory.CreateDirectory(path);
             Directory.CreateDirectory(Path.Combine(path, "Desktop"));
             Directory.CreateDirectory(Path.Combine(path, "Downloads"));
-            
-            OnPropertyRaised(nameof(Profiles));
+
+            UpdateProfiles();
         }
 
         public void Delete(string profileName)
         {
-            string path = GetProfilePath(profileName);
+            if (!IsDefault(profileName))
+            {
+                string path = GetProfilePath(profileName);
 
-            if (Directory.Exists(path))
-                Directory.Delete(path, true);
+                if (Directory.Exists(path))
+                    Directory.Delete(path, true);
+            }
 
-            OnPropertyRaised(nameof(Profiles));
+            UpdateProfiles();
         }
 
-        private string GetDisabledFilePath(string profileName) => Path.Combine(GetProfilePath(profileName), "MMT.disabled");
+        private static string GetDisabledFilePath(string profileName) => Path.Combine(GetProfilePath(profileName), "MMT.disabled");
 
-        private bool IsDisabled(string profileName) => File.Exists(GetDisabledFilePath(profileName));
+        private static bool IsDisabled(string profileName) => File.Exists(GetDisabledFilePath(profileName));
 
         public void Enable(string profileName)
         {
             if (IsDisabled(profileName))
             {
                 File.Delete(GetDisabledFilePath(profileName));
-                OnPropertyRaised(nameof(Profiles));
+                UpdateProfiles();
             }
         }
 
@@ -92,8 +87,10 @@ namespace MMT.Core
             if (!IsDisabled(profileName))
             {
                 using (File.Create(GetDisabledFilePath(profileName))) { }
-                OnPropertyRaised(nameof(Profiles));
+                UpdateProfiles();
             }
         }
+
+        public static bool IsDefault(string profileName) => string.Equals(profileName, "[Default]");
     }
 }

--- a/src/MMT.Core/StaticResources.cs
+++ b/src/MMT.Core/StaticResources.cs
@@ -4,7 +4,7 @@ namespace MMT.Core
 {
     public static class StaticResources
     {
-        private static string _userProfile;
+        private static string? _userProfile;
         public static string UserProfile
         {
             get
@@ -16,7 +16,7 @@ namespace MMT.Core
             }
         }
 
-        private static string _localAppData;
+        private static string? _localAppData;
         public static string LocalAppData
         {
             get

--- a/src/MMT.Core/TeamsLauncher.cs
+++ b/src/MMT.Core/TeamsLauncher.cs
@@ -11,6 +11,8 @@ namespace MMT.Core
             if (string.IsNullOrWhiteSpace(profile.Name))
                 throw new ArgumentNullException("Profile name is required.");
 
+            string? originalUserProfilePath = Environment.GetEnvironmentVariable("USERPROFILE");
+
             // Profile called [Default] will start Teams in the current users profile (like not using MMT)
             if (!profile.IsDefault)
             {
@@ -21,6 +23,9 @@ namespace MMT.Core
 
             string updateExePath = Path.Combine(StaticResources.UserProfile, StaticResources.UpdateExe);
             UpdateProfileAndStartTeams(updateExePath);
+
+            // revert USERPROFILE path to default
+            Environment.SetEnvironmentVariable("USERPROFILE", originalUserProfilePath);
         }
 
         private void UpdateProfileAndStartTeams(string updatePath)

--- a/src/MMT.Core/TeamsLauncher.cs
+++ b/src/MMT.Core/TeamsLauncher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 namespace MMT.Core
 {
@@ -9,14 +10,14 @@ namespace MMT.Core
         public void Start(Profile profile)
         {
             if (string.IsNullOrWhiteSpace(profile.Name))
+            {
                 throw new ArgumentNullException("Profile name is required.");
+            }
 
             string? originalUserProfilePath = Environment.GetEnvironmentVariable("USERPROFILE");
 
-            // Profile called [Default] will start Teams in the current users profile (like not using MMT)
             if (!profile.IsDefault)
             {
-                // Overwrite env variable to force teams to run with the selected profile
                 string mmtUserProfilePath = Path.Combine(StaticResources.LocalAppData, StaticResources.CustomProfiles, profile.Name);
                 Environment.SetEnvironmentVariable("USERPROFILE", mmtUserProfilePath);
             }
@@ -24,39 +25,31 @@ namespace MMT.Core
             string updateExePath = Path.Combine(StaticResources.UserProfile, StaticResources.UpdateExe);
             UpdateProfileAndStartTeams(updateExePath);
 
-            // revert USERPROFILE path to default
             Environment.SetEnvironmentVariable("USERPROFILE", originalUserProfilePath);
         }
 
         private void UpdateProfileAndStartTeams(string updatePath)
         {
-            try
+            var updateExeProcess = new Process
             {
-                Process? updateExeProcess = new Process
+                StartInfo = new ProcessStartInfo
                 {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = updatePath,
-                        Arguments = "--processStart Teams.exe",
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true,
-                        CreateNoWindow = true
-                    }
-                };
-                updateExeProcess.Start();
-
-                while (!updateExeProcess.StandardOutput.EndOfStream)
-                {
-                    string? line = updateExeProcess.StandardOutput.ReadLine();
-                    Console.WriteLine(line);
+                    FileName = updatePath,
+                    Arguments = "--processStart Teams.exe",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    CreateNoWindow = true
                 }
+            };
 
-                updateExeProcess.WaitForExit();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e.ToString());
-            }
-        }        
+            updateExeProcess.Start();
+            while (!updateExeProcess.StandardOutput.EndOfStream) { }
+            updateExeProcess.WaitForExit();
+        }
+
+        public void CloseAllInstances()
+        {
+            Process.GetProcessesByName("Teams").ToList().ForEach(p => p.Kill());
+        }
     }
 }

--- a/src/MMT.Core/TeamsLauncher.cs
+++ b/src/MMT.Core/TeamsLauncher.cs
@@ -5,20 +5,21 @@ using System.IO;
 namespace MMT.Core
 {
     public class TeamsLauncher
-    {        
+    {
         public void Start(string profileName)
         {
             if (string.IsNullOrWhiteSpace(profileName))
                 throw new ArgumentNullException("Profile name is required.");
 
-            string oldUserProfile = StaticResources.UserProfile;
-            string userProfile = Path.Combine(StaticResources.LocalAppData, StaticResources.CustomProfiles, profileName);
-            Directory.CreateDirectory(userProfile);
-            Directory.CreateDirectory(Path.Combine(userProfile, "Desktop"));
-            Directory.CreateDirectory(Path.Combine(userProfile, "Downloads"));
-            Environment.SetEnvironmentVariable("USERPROFILE", userProfile);
-            string updateExePath = Path.Combine(oldUserProfile, StaticResources.UpdateExe);
-            
+            // Profile called [Default] will start Teams in the current users profile (like not using MMT)
+            if (!ProfileManager.IsDefault(profileName))
+            {
+                // Overwrite env variable to force teams to run with the selected profile
+                string mmtUserProfilePath = Path.Combine(StaticResources.LocalAppData, StaticResources.CustomProfiles, profileName);
+                Environment.SetEnvironmentVariable("USERPROFILE", mmtUserProfilePath);
+            }
+
+            string updateExePath = Path.Combine(StaticResources.UserProfile, StaticResources.UpdateExe);
             UpdateProfileAndStartTeams(updateExePath);
         }
 
@@ -49,7 +50,7 @@ namespace MMT.Core
             }
             catch (Exception e)
             {
-                Console.WriteLine(e.Message);
+                Console.WriteLine(e.ToString());
             }
         }        
     }

--- a/src/MMT.Core/TeamsLauncher.cs
+++ b/src/MMT.Core/TeamsLauncher.cs
@@ -6,16 +6,16 @@ namespace MMT.Core
 {
     public class TeamsLauncher
     {
-        public void Start(string profileName)
+        public void Start(Profile profile)
         {
-            if (string.IsNullOrWhiteSpace(profileName))
+            if (string.IsNullOrWhiteSpace(profile.Name))
                 throw new ArgumentNullException("Profile name is required.");
 
             // Profile called [Default] will start Teams in the current users profile (like not using MMT)
-            if (!ProfileManager.IsDefault(profileName))
+            if (!profile.IsDefault)
             {
                 // Overwrite env variable to force teams to run with the selected profile
-                string mmtUserProfilePath = Path.Combine(StaticResources.LocalAppData, StaticResources.CustomProfiles, profileName);
+                string mmtUserProfilePath = Path.Combine(StaticResources.LocalAppData, StaticResources.CustomProfiles, profile.Name);
                 Environment.SetEnvironmentVariable("USERPROFILE", mmtUserProfilePath);
             }
 
@@ -27,7 +27,7 @@ namespace MMT.Core
         {
             try
             {
-                var updateExeProcess = new Process
+                Process? updateExeProcess = new Process
                 {
                     StartInfo = new ProcessStartInfo
                     {
@@ -42,7 +42,7 @@ namespace MMT.Core
 
                 while (!updateExeProcess.StandardOutput.EndOfStream)
                 {
-                    var line = updateExeProcess.StandardOutput.ReadLine();
+                    string? line = updateExeProcess.StandardOutput.ReadLine();
                     Console.WriteLine(line);
                 }
 

--- a/src/MMT.UI/MMT.UI.csproj
+++ b/src/MMT.UI/MMT.UI.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <EmbeddedResource Update="Resource.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resource.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>

--- a/src/MMT.UI/MMT.UI.csproj
+++ b/src/MMT.UI/MMT.UI.csproj
@@ -13,8 +13,8 @@
     <Copyright>Cleriton Cunha</Copyright>
     <Description>Launcher to manage profiles and open multiple instances of Microsoft Teams desktop version. It's compatible with many accounts and organizations (tenants).</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <AssemblyVersion>1.0.0.4</AssemblyVersion>
-    <FileVersion>1.0.0.4</FileVersion>
+    <AssemblyVersion>1.0.0.5</AssemblyVersion>
+    <FileVersion>1.0.0.5</FileVersion>
     <Version>1.0.0.4</Version>
     <Win32Resource />        
   </PropertyGroup>

--- a/src/MMT.UI/MainWindow.xaml
+++ b/src/MMT.UI/MainWindow.xaml
@@ -4,8 +4,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"      
         xmlns:mah="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"                                
-        xmlns:local="clr-namespace:MMT.UI"                  
-        mc:Ignorable="d"
+        xmlns:local="clr-namespace:MMT.UI" xmlns:core="clr-namespace:MMT.Core;assembly=MMT.Core" d:DataContext="{d:DesignInstance Type=core:ProfileManager}"
+                  mc:Ignorable="d"
         Title="Multi Microsoft Teams" Height="250" Width="400" WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize" StateChanged="MetroWindow_StateChanged">
     <Grid>
         <Grid.RowDefinitions>
@@ -26,7 +26,13 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <ListBox Grid.Row="0" Name="lstProfiles" Margin="0,0,0,8" KeyUp="LstProfiles_KeyUp" MouseDoubleClick="LstProfiles_MouseDoubleClick" SelectionMode="Multiple" />
+                    <ListBox Grid.Row="0" Name="lstProfiles" ItemsSource="{Binding Profiles}" Margin="0,0,0,8" KeyUp="LstProfiles_KeyUp" SelectionMode="Multiple">
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                                <EventSetter Event="MouseDoubleClick" Handler="LstProfiles_MouseDoubleClick"/>
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                    </ListBox>
 
                     <Grid Grid.Row="1" Margin="5" Height="Auto">
                         <StackPanel HorizontalAlignment="Left" Orientation="Horizontal">

--- a/src/MMT.UI/MainWindow.xaml
+++ b/src/MMT.UI/MainWindow.xaml
@@ -26,11 +26,12 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <ListBox Grid.Row="0" Name="lstProfiles" Margin="0,0,0,8" KeyUp="LstProfiles_KeyUp" MouseDoubleClick="LstProfiles_MouseDoubleClick" />
+                    <ListBox Grid.Row="0" Name="lstProfiles" Margin="0,0,0,8" KeyUp="LstProfiles_KeyUp" MouseDoubleClick="LstProfiles_MouseDoubleClick" SelectionMode="Multiple" />
 
                     <Grid Grid.Row="1" Margin="5" Height="Auto">
                         <StackPanel HorizontalAlignment="Left" Orientation="Horizontal">
-                            <Button Name="btnLaunchTeams"  Width="100" Content="Launch Teams" Click="BtnLaunchTeams_Click"/>
+                            <Button Name="btnLaunchTeams"  Width="100" Content="Launch Teams" Click="BtnLaunchTeams_Click" IsEnabled="{Binding ElementName=lstProfiles, Path=SelectedItems.Count}">
+                            </Button>
                             <CheckBox Name="chkAutoStart" Margin="8,0,0,0" HorizontalAlignment="Left" Content="Auto start" Click="ChkAutoStart_Click"/>
                         </StackPanel>
                         <Button Name="btnNewProfile" HorizontalAlignment="Right" Width="100" Content="New profile" Click="BtnNewProfile_Click"/>

--- a/src/MMT.UI/MainWindow.xaml
+++ b/src/MMT.UI/MainWindow.xaml
@@ -4,9 +4,12 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"      
         xmlns:mah="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"                                
-        xmlns:local="clr-namespace:MMT.UI" xmlns:core="clr-namespace:MMT.Core;assembly=MMT.Core" d:DataContext="{d:DesignInstance Type=core:ProfileManager}"
+        xmlns:core="clr-namespace:MMT.Core;assembly=MMT.Core" d:DataContext="{d:DesignInstance Type=core:ProfileManager}"
                   mc:Ignorable="d"
         Title="Multi Microsoft Teams" Height="250" Width="400" WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize" StateChanged="MetroWindow_StateChanged">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition/>
@@ -27,6 +30,24 @@
                     </Grid.RowDefinitions>
 
                     <ListBox Grid.Row="0" Name="lstProfiles" ItemsSource="{Binding Profiles}" Margin="0,0,0,8" KeyUp="LstProfiles_KeyUp" SelectionMode="Multiple">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate DataType="{x:Type core:Profile}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="❌ " Foreground="Gray" Visibility="{Binding IsDisabled, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Text="{Binding Name}">
+                                        <TextBlock.Resources>
+                                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsDisabled}" Value="True">
+                                                        <Setter Property="TextBox.Foreground" Value="Gray"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Resources>
+                                    </TextBlock>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
                         <ListBox.ItemContainerStyle>
                             <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
                                 <EventSetter Event="MouseDoubleClick" Handler="LstProfiles_MouseDoubleClick"/>

--- a/src/MMT.UI/MainWindow.xaml
+++ b/src/MMT.UI/MainWindow.xaml
@@ -5,10 +5,19 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"      
         xmlns:mah="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"                                
         xmlns:core="clr-namespace:MMT.Core;assembly=MMT.Core" d:DataContext="{d:DesignInstance Type=core:ProfileManager}"
-                  mc:Ignorable="d"
+        xmlns:local="clr-namespace:MMT.UI"
+        mc:Ignorable="d"
+        xmlns:tb="http://www.hardcodet.net/taskbar"
         Title="Multi Microsoft Teams" Height="250" Width="400" WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize" StateChanged="MetroWindow_StateChanged">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <ContextMenu x:Key="trayContextMenu" Visibility="Collapsed">
+            <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
+                <Setter Property="IsEnabled" Value="{Binding IsEnabled}" />
+                <Setter Property="Header" Value="{Binding Name}" />
+                <EventSetter Event="Click" Handler="MenuItem_Click" />
+            </Style>
+        </ContextMenu>
     </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
@@ -82,5 +91,14 @@
                 </Grid>
             </TabItem>
         </TabControl>
+
+        <tb:TaskbarIcon x:Name="_tray" 
+                        Icon="{x:Static local:Resource.Taskbar}" 
+                        DataContext="{Binding Profiles}" 
+                        ToolTipText="{x:Static core:StaticResources.AppName}" 
+                        Visibility="Collapsed" 
+                        TrayMouseDoubleClick="TrayMouseDoubleClick" 
+                        ContextMenu="{StaticResource trayContextMenu}" 
+        />
     </Grid>
 </mah:MetroWindow>

--- a/src/MMT.UI/MainWindow.xaml
+++ b/src/MMT.UI/MainWindow.xaml
@@ -40,11 +40,11 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <ListBox Grid.Row="0" Name="lstProfiles" ItemsSource="{Binding Profiles}" Margin="0,0,0,8" KeyUp="LstProfiles_KeyUp" SelectionMode="Multiple">
+                    <ListBox Grid.Row="0" Name="lstProfiles" ItemsSource="{Binding Profiles}" Margin="0,0,0,8" KeyUp="LstProfiles_KeyUp" SelectionMode="Single">
                         <ListBox.ItemTemplate>
                             <DataTemplate DataType="{x:Type core:Profile}">
                                 <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="❌ " Foreground="Gray" Visibility="{Binding IsDisabled, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Text="[Disabled] " Foreground="Gray" Visibility="{Binding IsDisabled, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                     <TextBlock Text="{Binding Name}">
                                         <TextBlock.Resources>
                                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">

--- a/src/MMT.UI/MainWindow.xaml
+++ b/src/MMT.UI/MainWindow.xaml
@@ -11,12 +11,14 @@
         Title="Multi Microsoft Teams" Height="250" Width="400" WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize" StateChanged="MetroWindow_StateChanged">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-        <ContextMenu x:Key="trayContextMenu" Visibility="Collapsed">
-            <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
-                <Setter Property="IsEnabled" Value="{Binding IsEnabled}" />
-                <Setter Property="Header" Value="{Binding Name}" />
-                <EventSetter Event="Click" Handler="MenuItem_Click" />
-            </Style>
+        <ContextMenu ItemsSource="{Binding Profiles}"  x:Key="trayContextMenu">
+            <ContextMenu.ItemContainerStyle>
+                <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
+                    <Setter Property="IsEnabled" Value="{Binding IsEnabled}" />
+                    <Setter Property="Header" Value="{Binding Name}" />
+                    <EventSetter Event="Click" Handler="MenuItem_Click" />
+                </Style>
+            </ContextMenu.ItemContainerStyle>
         </ContextMenu>
     </Window.Resources>
     <Grid>
@@ -94,7 +96,6 @@
 
         <tb:TaskbarIcon x:Name="_tray" 
                         Icon="{x:Static local:Resource.Taskbar}" 
-                        DataContext="{Binding Profiles}" 
                         ToolTipText="{x:Static core:StaticResources.AppName}" 
                         Visibility="Collapsed" 
                         TrayMouseDoubleClick="TrayMouseDoubleClick" 

--- a/src/MMT.UI/MainWindow.xaml.cs
+++ b/src/MMT.UI/MainWindow.xaml.cs
@@ -73,8 +73,12 @@ namespace MMT.UI
                 Thread thread = new Thread(() =>
                 {
                     foreach (Profile item in lstProfiles.Items.OfType<Profile>())
+                    {
                         if (!item.IsDisabled)
+                        {
                             _teamsLauncher.Start(item);
+                        }
+                    }
                 });
                 thread.Start();
             }
@@ -98,9 +102,13 @@ namespace MMT.UI
         private void ChkAutoStart_Click(object sender, RoutedEventArgs e)
         {
             if (chkAutoStart.IsChecked.HasValue && chkAutoStart.IsChecked.Value)
+            {
                 _registryManager.AddApplicationInStartup(StaticResources.AppName);
+            }
             else if (_registryManager.IsApplicationInStartup(StaticResources.AppName))
+            {
                 _registryManager.RemoveApplicationFromStartup(StaticResources.AppName);
+            }
         }
 
         private void BtnNewProfile_Click(object sender, RoutedEventArgs e)
@@ -175,9 +183,13 @@ namespace MMT.UI
             if (sender is ListBoxItem item && item.DataContext is Profile selectedProfile)
             {
                 if (selectedProfile.IsDisabled)
+                {
                     _profileManager.Enable(selectedProfile);
+                }
                 else if (await MessageHelper.Confirm($"Disable profile?\nProfile name: {selectedProfile.Name}") == MessageDialogResult.Affirmative)
+                {
                     _profileManager.Disable(selectedProfile);
+                }
             }
         }
     }

--- a/src/MMT.UI/MainWindow.xaml.cs
+++ b/src/MMT.UI/MainWindow.xaml.cs
@@ -146,7 +146,6 @@ namespace MMT.UI
             catch (Exception ex)
             {
                 MessageHelper.Info(ex.Message);
-                txtProfileName.Focus();
             }
         }
 

--- a/src/MMT.UI/MainWindow.xaml.cs
+++ b/src/MMT.UI/MainWindow.xaml.cs
@@ -5,8 +5,10 @@ using MMT.Core;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Navigation;
 
@@ -61,6 +63,25 @@ namespace MMT.UI
             _tray.TrayMouseDoubleClick += TrayMouseDoubleClick;
             _tray.ToolTipText = StaticResources.AppName;
             _tray.Visibility = Visibility.Collapsed;
+            if (lstProfiles.Items?.Count > 0)
+            {
+                _tray.ContextMenu = new ContextMenu();
+                lstProfiles.Items.OfType<string>().ToList().ForEach((item) =>
+                {
+                    var menuItem = new MenuItem() { Header = item };
+                    menuItem.Click += MenuItem_Click;
+                    _tray.ContextMenu.Items.Add(menuItem);
+                });
+            }
+        }
+
+        private void MenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            var menuItem = sender as MenuItem;
+            if (sender != null)
+            {
+                _teamsLauncher.Start(menuItem.Header.ToString());
+            }
         }
 
         private void TrayMouseDoubleClick(object sender, RoutedEventArgs e)
@@ -142,8 +163,16 @@ namespace MMT.UI
         {
             try
             {
-                if (lstProfiles.SelectedItem != null && !lstProfiles.SelectedItem.ToString().StartsWith("[Disabled]"))
-                    _teamsLauncher.Start(lstProfiles.SelectedItem.ToString());
+                if (lstProfiles.SelectedItems?.Count > 0)
+                {
+                    lstProfiles.SelectedItems.OfType<string>()
+                        .Where((item) => !item.StartsWith("[Disabled]"))
+                        .ToList()
+                        .ForEach((item) =>
+                    {
+                        _teamsLauncher.Start(item);
+                    });
+                }
             }
             catch (Exception ex)
             {
@@ -152,7 +181,7 @@ namespace MMT.UI
             }
         }
 
-        private async void LstProfiles_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        private async void LstProfiles_KeyUp(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Delete)
             {

--- a/src/MMT.UI/MainWindow.xaml.cs
+++ b/src/MMT.UI/MainWindow.xaml.cs
@@ -18,7 +18,6 @@ namespace MMT.UI
         private readonly ProfileManager _profileManager;
         private readonly TeamsLauncher _teamsLauncher;
         private readonly RegistryManager _registryManager;
-        private TaskbarIcon _tray;
 
         public MainWindow()
         {
@@ -28,7 +27,6 @@ namespace MMT.UI
             _registryManager = new RegistryManager();
             DataContext = _profileManager;
             ChangeTabVisibility();
-            CreateTray();
             AutoStartCheck();
         }
 
@@ -47,32 +45,9 @@ namespace MMT.UI
                 tbcMain.SelectedItem = tbiNewProfile;
             }
         }
-
-        private void CreateTray()
-        {
-            _tray = new TaskbarIcon
-            {
-                Icon = Resource.Taskbar,
-                ToolTipText = StaticResources.AppName,
-                Visibility = Visibility.Collapsed
-            };
-            _tray.TrayMouseDoubleClick += TrayMouseDoubleClick;
-            if (DataContext is ProfileManager pm && pm.Profiles.Count > 0)
-            {
-                _tray.ContextMenu = new ContextMenu();
-                pm.Profiles.ToList().ForEach((profile) =>
-                {
-                    MenuItem menuItem = new MenuItem() { Header = profile.Name, DataContext = profile };
-                    menuItem.Click += MenuItem_Click;
-                    _tray.ContextMenu.Items.Add(menuItem);
-                });
-            }
-        }
-
         private void MenuItem_Click(object sender, RoutedEventArgs e)
         {
-            MenuItem menuItem = sender as MenuItem;
-            if (sender != null && menuItem.DataContext is Profile profile)
+            if (sender is MenuItem menuItem && menuItem.DataContext is Profile profile)
             {
                 _teamsLauncher.Start(profile);
             }

--- a/src/MMT.UI/MainWindow.xaml.cs
+++ b/src/MMT.UI/MainWindow.xaml.cs
@@ -51,11 +51,13 @@ namespace MMT.UI
 
         private void CreateTray()
         {
-            _tray = new TaskbarIcon();
-            _tray.Icon = Resource.Taskbar;
+            _tray = new TaskbarIcon
+            {
+                Icon = Resource.Taskbar,
+                ToolTipText = StaticResources.AppName,
+                Visibility = Visibility.Collapsed
+            };
             _tray.TrayMouseDoubleClick += TrayMouseDoubleClick;
-            _tray.ToolTipText = StaticResources.AppName;
-            _tray.Visibility = Visibility.Collapsed;
             var items = DataContext as IList<string>;
             if (items?.Count > 0)
             {
@@ -197,13 +199,11 @@ namespace MMT.UI
 
         private async void LstProfiles_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            var item = sender as ListBoxItem;
-            if (item != null)
+            if (sender is ListBoxItem item && item.DataContext is string selectedProfile)
             {
-                string selectedProfile = item.DataContext.ToString();
                 if (selectedProfile.StartsWith("[Disabled]"))
                     _profileManager.Enable(selectedProfile);
-                else if (await MessageHelper.Confirm(string.Format("Disable profile?\nProfile name: {0}", selectedProfile)) == MessageDialogResult.Affirmative)
+                else if (await MessageHelper.Confirm($"Disable profile?\nProfile name: {selectedProfile}") == MessageDialogResult.Affirmative)
                     _profileManager.Disable(selectedProfile);
             }
         }

--- a/src/MMT.UI/Resource.Designer.cs
+++ b/src/MMT.UI/Resource.Designer.cs
@@ -22,7 +22,7 @@ namespace MMT.UI {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resource {
+    public class Resource {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace MMT.UI {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MMT.UI.Resource", typeof(Resource).Assembly);
@@ -51,7 +51,7 @@ namespace MMT.UI {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace MMT.UI {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
         /// </summary>
-        internal static System.Drawing.Icon Taskbar {
+        public static System.Drawing.Icon Taskbar {
             get {
                 object obj = ResourceManager.GetObject("Taskbar", resourceCulture);
                 return ((System.Drawing.Icon)(obj));

--- a/src/MMT.UI/Resource.resx
+++ b/src/MMT.UI/Resource.resx
@@ -117,8 +117,80 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="Taskbar" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Taskbar.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="Taskbar" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAAAAAAAEAIACLEAAAFgAAAIlQTkcNChoKAAAADUlIRFIAAAEAAAABMQgGAAAAk1R8bgAAEFJJ
+        REFUeJzt3X10z/X/x/HnZnOxzHUrzjouz4p2kEjINWUhSTl0iFx05KqmMDGzta85riLHRYSkSM4SpZIS
+        LcLYCa20g+Q4agjZXLN9/6jf99f6jLZ9Pp/38/X+vO63c/ZP0/v9OMP9bN7vz+ctAgAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKCIgkQkX3sEAB3B2gMA6CEAgMUIAGAxAgBY
+        jAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBY
+        jAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBY
+        jAAAFiMAgMWMCEB2drbk5+cH3MeZM2ckIiJC+8vrag0aNJDc3Fz130t/fPzyyy/aX14zAhCoKleuLImJ
+        idozXG3ixIly2223ac8IWATAz7p27ao9wdU6d+6sPSGgEQA/u+uuu2Ty5MnaM1xp9uzZcvvtt2vPCGgE
+        wAG9e/fWnuBKjz32mPaEgEcAHNCgQQMZNGiQ9gxXiY2Nlbp162rPCHgEwAFBQUEyePBg7Rmu0q9fP+0J
+        ViAADmnatKl06NBBe4Yr9OrVSxo1aqQ9wwoEwCGlS5eW2NhY7RmuMHz4cClVqpT2DCsQAAe1bdtW6tSp
+        oz3DaE2aNJEWLVpoz7AGAXBQeHi4xMfHa88wWlxcnJQrV057hjUIgMO6dOmiPcFY4eHh0rFjR+0ZViEA
+        Drvzzjtl2rRp2jOMlJKSIlWqVNGeYRUCoKBnz57aE4zUrVs37QnWIQAKoqKiZOTIkdozjBIXFyc1a9bU
+        nmEdAqDkmWee0Z5glL59+2pPsBIBUHLfffdJjx49tGcYoV+/fhIdHa09w0oEQElISIiMGDFCe4YRhg4d
+        KsHB/FHUwFddUatWraRhw4baM1S1atVKHnjgAe0Z1iIAisLCwmTChAnaM1S9/PLLUrZsWe0Z1iIAyjp1
+        6qQ9QU1ERIS0a9dOe4bVCICyatWqydy5c7VnqEhOTpZKlSppz7AaATBA9+7dtSeoiImJ0Z5gPQJggNq1
+        a8u4ceO0ZzgqISFBIiMjtWdYjwAY4umnn9ae4CjeJ9EMBMAQ0dHR0qdPH+0Zjhg0aJDUr19fewaEABij
+        VKlSMmzYMO0Zjhg8eLAEBQVpz4AQAKM0b95cWrVqpT3Drzp06CBNmzbVnoG/EACDlC1bVl566SXtGX4V
+        GxsrpUuX1p6BvxAAw7Rv3z5gHyhap04dadOmjfYM/A0BMEylSpUkOTlZe4ZfxMfHS4UKFbRn4G8IgIEC
+        9QaZRx55RHsC/oEAGCgyMlKmTJmiPcOnpk6dKtWrV9eegX8gAIZ66qmntCf41BNPPKE9AYUgAIaqX79+
+        wDxP8Pnnn5eoqCjtGSgEATBUID1QdMCAAdz4YygCYLCmTZtK586dtWd4JSYmRpo0aaI9AzdBAAwWGhoq
+        L7zwgvYMr4wePVpCQ0O1Z+AmCIDh2rRp49oHikZFRclDDz2kPQO3QAAMFx4eLgkJCdozSiQ+Pl7Kly+v
+        PQO3QABcwK030Dz88MPaE/AvCIAL3HHHHTJ9+nTtGcUyc+bMgH1NQyAhAC7htgeKPv7449oTUAQEwCXq
+        1asno0aN0p5RJC+++KLUrVtXewaKgAC4iFseKNq/f3/tCSgiAuAijRs3Nv5HgZ49e1r/uDM3IQAuEhIS
+        IsOHD9eecUsjRoyQkJAQ7RkoIgLgMi1btjT21tomTZpIixYttGegGAiAy4SFhcn48eO1ZxRq/PjxEhYW
+        pj0DxUAAXKhjx44SHh6uPaOA8PBw6dixo/YMFBMBcKGqVavK1KlTtWcUMHXqVKlatar2DBQTAXCpbt26
+        aU8owLQ9KBoC4FK1atWSuLg47Rki8ufP/rVq1dKegRIgAC7Wt29f7QkiYs4OFB8BcLHo6Gjp16+f6oY+
+        ffpIdHS06gaUHAFwseDgYBk6dKjqhmHDhkmpUqVUN6DkCIDLNW/eXFq3bq1y7gcffFCaN2+ucm74BgFw
+        uTJlysiYMWNUzj127FgpW7asyrnhGwQgALRv314iIyMdPWdERIS0b9/e0XPC9whAAKhYsaLj7xuYlJQk
+        lStXdvSc8D0CUALZ2dnaEzw8+uijjp6va9eujp7vZnJzc+XixYvaM1yLAJTArl275OrVq9ozCqhRo4Yk
+        JSU5cq7Jkyc7/iPHzezYsUPy8vK0Z7gWASiBS5cuyd69e7VneHjyyScdOU/v3r0dOc+/uXHjhixevFh7
+        hqsRgBJ65513tCd4uOeee+S5557z6zkGDhwo9evX9+s5iiozM1NSU1O1Z7gaASihBQsWyOHDh7VnFBAU
+        FCTPPvusX88xZMgQCQ42448Nf/m9Z8bvpEtt3LhRe4KH+++/X2JiYvxy7Hbt2kmzZs38cuziOnHihGP/
+        5hHICIAXJk2aJGfPntWeUUBoaKjf3j58zJgxUrp0ab8cu7g2b96sPSEgEAAv5OTkyLZt27RneGjdurVE
+        RUX59JiRkZHStm1bnx6zpC5cuGDcG6K4FQHw0rx58+TatWvaMwooX768xMfH+/SYiYmJUqFCBZ8es6R2
+        7twpWVlZ2jMCAgHw0pYtWyQjI0N7hgdfP5izS5cuPj1eSeXl5cmbb76pPSNgEAAfePfdd7UneIiIiJCZ
+        M2f65FjJyclSo0YNnxzLW5mZmfLee+9pzwgYBMAH5s2bJ0eOHNGe4cFXD+js1auXT47jC+vWrdOeEFAI
+        gI98+umn2hM81K1bV2JjY706xrBhw+Tuu+/20SLv/Pbbb46/6CnQEQAfSUpKknPnzmnP8ODtW4YNHDhQ
+        goKCfLTGO1988YX2hIBDAHzk5MmTkpaWpj3DQ8OGDUv8LXxMTIwxjyG7ePGizJgxQ3tGwCEAPjR//nzj
+        Lgl680DRUaNGSWhoqI8XlcyuXbtk//792jMCDgHwoU2bNsl3332nPcNDixYtin0Lb1RUlNp7Df5TXl6e
+        LFu2THtGQCIAPrZ69WrtCR7KlSsnY8eOLdb/Ex8fL+XLl/fTouI5ePCgka++DAQEwMdee+01OXr0qPYM
+        D8V9oKivbyTyBpf+/IcA+MFnn32mPcFDlSpVZNq0aUX6tTNmzJCIiAg/Lyqa7OxsmTRpkvaMgEUA/CAh
+        IUH++OMP7Rkeivo+fr66gcgXtmzZoj0hoBEAPzh58qR888032jM81KxZU1555ZVb/prRo0dLvXr1HFp0
+        a5cuXfLZ7cwoHAHwk4ULF8r169e1Z3jo06fPLT/fv39/h5b8u927dxv5QqtAQgD8ZOPGjbJv3z7tGR7u
+        vfdeGTBgQKGf69GjhzRu3NjhRYXLz8+X5cuXa88IeATAj9asWaM9wUNwcLAMGTKk0M+NHDlSQkJCHF5U
+        uIMHD8qKFSu0ZwQ8AuBHM2bMkGPHjmnP8NCsWTNp165dgf/WsGFDadmypc6gQmzYsEF7ghUIgJ99/vnn
+        2hM8lClTxuNVghMmTJCwsDClRQWdOnVK4uLitGdYgQD4WWJiopw/f157hoe2bdsWeLpPp06dFNcUxKU/
+        5xAAPzt+/Lhs375de4aHihUrSmJiooiIzJ07V6pVq6a86E+XL1+WWbNmac+wBgFwwBtvvGHkJcH/e35A
+        9+7dlZf8v/T0dElPT9eeYQ0C4ID169fLgQMHtGd4qF69uqSmpkrt2rW1p4jIn5f++Jd/ZxEAh6xdu1Z7
+        QqF69uypPeF/srKyZOnSpdozrEIAHJKSkiLHjx/XnuHBlLf7EhH56KOPtCdYhwA4yMRLgqY4ffp0sd+z
+        AN4jAA76z3/+I7m5udozjLR161btCVYiAA46cuSI7NixQ3uGca5cuSJz5szRnmElAuCwRYsWyY0bN7Rn
+        GGXPnj1G3ithAwLgsHXr1sn333+vPcMY+fn58vbbb2vPsBYBUJCamqo9wRiHDh2SxYsXa8+wFgFQ8Oqr
+        r8qJEye0Zxhh48aN2hOsRgCUcElQ5MyZMzJ58mTtGVYjAEpSUlLkwoUL2jNUbd26VXJycrRnWI0AKMnK
+        ypJvv/1We4aaq1evcunPAARA0ZIlSyQvL097hoqMjAwjH6ZqGwKg6P3335fMzEztGSpWrlypPQFCANR9
+        8MEH2hMcd/jwYVmwYIH2DAgBUDdlyhT59ddftWc46pNPPtGegL8QAAN8+eWX2hMcc/bsWZk4caL2DPyF
+        ABggJSVFLl68qD3DEV9//TWX/gxCAAzwww8/yM6dO7Vn+N21a9fk9ddf156BvyEAhli6dGnAXxLMyMjg
+        Lb8NQwAMsWrVKvnxxx+1Z/jVqlWrtCfgHwiAQT788EPtCX7z888/8+2/gQiAQSZNmiTZ2dnaM/yCS39m
+        IgCGCcRLgufOnZOkpCTtGSgEATDMrFmz5NKlS9ozfCotLU1OnjypPQOFIACGycjIkN27d2vP8Jlr167J
+        /PnztWfgJgiAgZYvXx4wlwT37dsnmzZt0p6BmyAABlqxYoX89NNP2jN8YvXq1doTcAsEwFDr16/XnuC1
+        o0ePyuzZs7Vn4BYIgKEmTJggp06d0p7hFb71Nx8BMJibb5s9f/68JCcna8/AvyAABps1a5ZcvnxZe0aJ
+        pKWlGfk0ZBREAAyWnp4u6enp2jOK7fr167Jw4ULtGSgCAmC4t956S/Lz87VnFMv+/ft54IdLEADDLVu2
+        TLKysrRnFMuaNWu0J6CICIALbNiwQXtCkR07dkymT5+uPQNFRABcYNy4cXL69GntGUXCI8/chQC4xFdf
+        faU94V/l5ORIYmKi9gwUAwFwiblz58qVK1e0Z9zS9u3bufTnMgTAJbZv3y579uzRnnFT169fl0WLFmnP
+        QDERABdZsWKFsZcEDxw4EBCvX7ANAXCRJUuWyKFDh7RnFGrt2rXaE1ACBMBlPv74Y+0JHo4fPy4pKSna
+        M1ACBMBlEhIS5Pfff9eeUcDmzZu1J6CECIDL5OTkyLZt27Rn/E9ubi6v+nMxAuBCc+bMkatXr2rPEBGR
+        HTt2yJEjR7RnoIQIgAulpaXJ3r17tWfIjRs3ZPHixdoz4AUC4FIrV67UniCZmZmSmpqqPQNeIAAutXDh
+        QgkKClL9aNSokfaXAV4iAIDFCABgMQIAWIwAABYjAIDFCABgMQIAWIwAABYjAIDFCABgMQIAWIwAABYj
+        AIDFCABgMQIAWIwAABYjAIDFCABgMQIAWIwAABYjAIDFCABgMQIAWIwAABYjAIDFCABgMQIAWIwAABYj
+        AIDFCABgMQIAWIwAABYjAIDFCABgMQIAWIwAABYjAIDFCABgMQIAWIwAABYjAIDFCABgsSARydceAUAH
+        3wEAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBY
+        jAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBYjAAAFiMAgMUIAGAxAgBY
+        jAAAFiMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgKr/At0cq2D/TLssAAAAAElFTkSuQmCC
+</value>
   </data>
 </root>


### PR DESCRIPTION
Hi,

I liked your Project very much.
And I just wanted to add multi-select functionality, to be able to manually start multiple profiles at once.
It got out of control quickly.

* I changed the way a profile is marked as disabled from one single file to a file per profile.
* including backward compatibility to the old disabled-file style
* There is now always also the "[Default]" profile, which is using your normal profile folder. This is the Teams instance, which will be triggered if you click on Teams links somewhere outside of the Teams app.
* I made "Profile" an object to improve data binding possibilities
* also I replaced some code with XAML, because I think this is the way it "should" be in WPF, also I wanted to try.
* then I added a context menu to the try icon, which shows the profiles, so you are able to start these from the tray as well